### PR TITLE
Fix: change hgroup tag to div tag

### DIFF
--- a/practice/src/index.html
+++ b/practice/src/index.html
@@ -129,10 +129,10 @@
     <!-- Service section -->
     <section class="service-section">
       <div class="container wrapper-service">
-        <hgroup class="text service-heading">
+        <div class="text service-heading">
           <h3 class="main-title">Our Service</h3>
           <h4 class="secondary-title">We Offer Best Service</h4>
-        </hgroup>
+        </div>
         <div class="text service-content">
           <div class="service-topic">
             <h5 class="service-topic-title">Experienced guide</h5>
@@ -222,10 +222,10 @@
           </div>
         </div>
         <div class="text package-introduction">
-          <hgroup>
+          <div>
             <h3 class="main-title">Our Package</h3>
             <h4 class="secondary-title">Popular Trip Packages</h4>
-          </hgroup>
+          </div>
           <p class="description introduction-desc">The packages available include accommodation for travel needs and
             insurance.</p>
           <div class="package-evaluation">
@@ -511,12 +511,12 @@
     <section class="discount-section">
       <div class="container wrapper-discount">
         <div class="discount-body">
-          <hgroup class="text discount-heading">
+          <div class="text discount-heading">
             <h2 class="main-title">For beloved customers</h2>
             <h3 class="secondary-title discount-title">20% discount if you have used our trip services!</h3>
             <p class="description discount-description">Let's maximize your next holiday with us with the best experience.
             </p>
-          </hgroup>
+          </div>
           <a href="javascript:void(0)" class="btn btn-primary btn-claim">Claim Now</a>
         </div>
         <div class="text discount-comment">


### PR DESCRIPTION
Comment: Fix errors on https://validator.w3.org/: Element [h4], [h3] not allowed as child of element [hgroup] in this context.
Solution: Because the `hgroup` element is only allowed to contain 0 or more p elements, followed by` h1, h2, h3, h4, h5` or `h6` elements, followed by 0 or more `p` elements, I changed the `hgroup` element to a div element to be able to contain the `h `element
