### PR TITLE
Fix: add nav-link-active class and style it to display home page

### DIFF
--- a/practice/src/css/layouts/header.css
+++ b/practice/src/css/layouts/header.css
@@ -51,6 +51,10 @@
     }
   }
 
+  .nav-link-active {
+    color: var(--secondary-text-color);
+  }
+
   .header-logo {
     gap: 5px;
   }

--- a/practice/src/index.html
+++ b/practice/src/index.html
@@ -31,7 +31,7 @@
       <nav>
         <ul class="nav-list">
           <li>
-            <a class="nav-link" href="javascript:void(0)" title="Home">Home</a>
+            <a class="nav-link nav-link-active" href="javascript:void(0)" title="Home">Home</a>
           </li>
           <li>
             <a class="nav-link" href="javascript:void(0)" title="Service">Our Service</a>


### PR DESCRIPTION
Comment: Shows blue text for the home of the navbar
Solution: 
- Add nav-link-active class for a tag containing "Home"
- Set color attribute for the nav-link-active class

Design: 
![image](https://github.com/JennyDoJD/html-css-training/assets/110828723/25df3470-4cbf-46c9-8f6a-a26ac083fb33)

Result: 
![image](https://github.com/JennyDoJD/html-css-training/assets/110828723/b39323cb-ae9b-46a6-bbaa-1dc5a6097c79)
