### PR TITLE
Fix: add placeholder for image if it hasn't loaded yet

### DIFF
--- a/practice/src/css/sections/destination.css
+++ b/practice/src/css/sections/destination.css
@@ -105,6 +105,10 @@
   padding-top: 50px;
 }
 
+.destination-image {
+  height: 280px;
+}
+
 /* Tablet */
 @media (min-width: 768px) {
   .destination-card {

--- a/practice/src/css/sections/discount.css
+++ b/practice/src/css/sections/discount.css
@@ -119,4 +119,9 @@
   .icon-heart {
     transform: translate(43%, -50%);
   }
+
+  .customer-image {
+    width: 54px;
+    height: 54px;
+  }
 }

--- a/practice/src/css/sections/package.css
+++ b/practice/src/css/sections/package.css
@@ -88,14 +88,24 @@
 }
 
 .package-card {
-  display: grid;
-  gap: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 30px;
+}
+
+.package-image {
+  height: 380px;
 }
   
 /* Tablet */
 @media (min-width: 768px) {
   .package-card {
-    grid-template-columns: repeat(auto-fit, minmax(200px, auto));
+    flex-direction: row;
+    justify-content: space-around;
+  }
+
+  .package-image {
+    width: 350px;
   }
 }
   
@@ -106,13 +116,16 @@
   }
 
   .wrapper-package {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(500px, auto));
-    gap: 60px;
+    display: flex;
+    justify-content: space-evenly;
     align-items: center;
   }
 
   .package-card {
     padding-left: 78px;
+  }
+
+  .package-image {
+    width: 280px;
   }
 }

--- a/practice/src/index.html
+++ b/practice/src/index.html
@@ -259,7 +259,7 @@
         <div class="text destination-card">
           <div class="destination-card-item">
             <a href="javascript:void(0)">
-              <figure>
+              <figure class="destination-image">
                 <img src="../src/assets/images/destination/paris.webp" alt="Paris" class="destination-card-item-image" loading="lazy">
               </figure>
               <div class="destination-rate">
@@ -289,7 +289,7 @@
           </div>
           <div class="destination-card-item">
             <a href="javascript:void(0)">
-              <figure>
+              <figure class="destination-image">
                 <img src="../src/assets/images/destination/siwidey.webp" alt="Ciwidey" class="destination-card-item-image"
                   loading="lazy">
               </figure>
@@ -320,7 +320,7 @@
           </div>
           <div class="destination-card-item">
             <a href="javascrip:void(0)">
-              <figure>
+              <figure class="destination-image">
                 <img src="../src/assets/images/destination/peucang.webp" alt="Peucang" class="destination-card-item-image" loading="lazy">
               </figure>
               <div class="destination-rate">
@@ -350,7 +350,7 @@
           </div>
           <div class="destination-card-item">
             <a href="javascrip:void(0)">
-              <figure>
+              <figure class="destination-image">
                 <img src="../src/assets/images/destination/dieng.webp" alt="Dieng" class="destination-card-item-image" loading="lazy">
               </figure>
               <div class="destination-rate">
@@ -380,7 +380,7 @@
           </div>
           <div class="destination-card-item">
             <a href="javascript:void(0)">
-              <figure>
+              <figure class="destination-image">
                 <img src="../src/assets/images/destination/kerinci.webp" alt="Kerinci" class="destination-card-item-image"
                   loading="lazy">
               </figure>
@@ -411,7 +411,7 @@
           </div>
           <div class="destination-card-item">
             <a href="javascript:void(0)">
-              <figure>
+              <figure class="destination-image">
                 <img src="../src/assets/images/destination/rinjani.webp" alt="Rinjani" class="destination-card-item-image" loading="lazy">
               </figure>
               <div class="destination-rate">
@@ -441,7 +441,7 @@
           </div>
           <div class="destination-card-item">
             <a href="javascript:void(0)">
-              <figure>
+              <figure class="destination-image">
                 <img src="../src/assets/images/destination/latimojong.webp" alt="Latimojong" class="destination-card-item-image"
                   loading="lazy">
               </figure>
@@ -472,7 +472,7 @@
           </div>
           <div class="destination-card-item">
             <a href="javascript:void(0)">
-              <figure>
+              <figure class="destination-image">
                 <img src="../src/assets/images/destination/prau.webp" alt="Parau" class="destination-card-item-image" loading="lazy">
               </figure>
               <div class="destination-rate">

--- a/practice/src/index.html
+++ b/practice/src/index.html
@@ -539,7 +539,9 @@
           </div>
           <p class="discount-comment-text">Thank you for helping my vacation. Amazing!</p>
           <div class="information-customer">
-            <img src="../src/assets/images/discount/avatar-rojali.png" alt="Rojali Customer" class="avatar-customer" loading="lazy"/>
+            <figure class="customer-image">
+              <img src="../src/assets/images/discount/avatar-rojali.png" alt="Rojali" class="avatar-customer" loading="lazy"/>
+            </figure>
             <div class="introduction-customer">
               <p class="customer-name">Rojali</p>
               <p class="customer-type">Backpacker</p>

--- a/practice/src/index.html
+++ b/practice/src/index.html
@@ -159,7 +159,7 @@
       <div class="container wrapper-package">
         <div class="package-card">
           <div class="package-card-item">
-            <figure>
+            <figure class="package-image">
               <img src="../src/assets/images/package/semeru.webp" alt="Semeru Mountain" class="package-card-item-image" loading="lazy">
             </figure>
             <div class="package-information">
@@ -190,7 +190,7 @@
             </div>
           </div>
           <div class="package-card-item">
-            <figure>
+            <figure class="package-image">
               <img src="../src/assets/images/package/bromo.webp" alt="Bromo" class="package-card-item-image" loading="lazy">
             </figure>
             <div class="package-information">


### PR DESCRIPTION
Comment: In case the image is not loaded, there should be a placeholder for it
Solution: Here I have set the height, width to the parent element of the image
Result after testing: 
![image](https://github.com/JennyDoJD/html-css-training/assets/110828723/2603e8a5-f435-4e4b-a4fb-5380a738bc5e)
![image](https://github.com/JennyDoJD/html-css-training/assets/110828723/0e0df3c5-03cd-4572-90a4-f7f7eaaf0245)
